### PR TITLE
Update LDAUDTFTest.java

### DIFF
--- a/core/src/test/java/hivemall/topicmodel/LDAUDTFTest.java
+++ b/core/src/test/java/hivemall/topicmodel/LDAUDTFTest.java
@@ -46,13 +46,21 @@ public class LDAUDTFTest {
 
         udtf.initialize(argOIs);
 
-        String[] doc1 = new String[]{"fruits:1", "healthy:1", "vegetables:1"};
-        String[] doc2 = new String[]{"apples:1", "avocados:1", "colds:1", "flu:1", "like:2", "oranges:1"};
+        String[] doc1 = new String[]{"xž:1", "healthy:1", "vegetables:1"};
+        String[] doc2 = new String[]{"apples:1", "na‹ve:1", "colds:1", "flu:1", "like:2", "oranges:1"};
         for (int it = 0; it < 5; it++) {
             udtf.process(new Object[]{ Arrays.asList(doc1) });
             udtf.process(new Object[]{ Arrays.asList(doc2) });
         }
-
+        
+        // LDA FAILS IN REAL LIFE BIG TIME!!!!
+        // Test could not possibly pick that up as udf.close() call is missing
+        // The errors are in runIterativeTraining of LDAUDTF
+        // the cause is encoding of characters, xž:1, for exapmple, then this bit is chopped into wrong size of bytes chunks and
+        // nio library goes cucumbers.
+        // Please, fix.
+        udtf.close();
+        
         SortedMap<Float, List<String>> topicWords;
 
         println("Topic 0:");


### PR DESCRIPTION
## What changes were proposed in this pull request?

I have found a major bug, without fixing people will not be able to use LDA, or perhaps other algorithms too.

I spotted the bug and made a small fix, I would like you to fix the rest. 

## What type of PR is it?

[Bug Fix]

## What is the Jira issue?

???

## How was this patch tested?

I intended to use LDA for my data, on EMR as usually, LDA failed to process my text. So I checked your test, and when added code to add my data to your test instead of your two lines. When it run successfully, I realized that the test may be faulty, and indeed, I think close() is called in real life, but not in the test. Same errors than on EMR showed up.

I found the lines in features that coursed the errors:
na‹ve:1
xž:1

Why I do not know, but that means that I have to pre-process data prior to testing LDA further, plus I start doubting whether it will work for other languages.

EMR error messages for different options for memory and number of reduces are below. Same source, same reason.

Diagnostic Messages for this Task:
Error: java.lang.RuntimeException: Hive Runtime Error while closing operators: Exception caused in the iterative training
        at org.apache.hadoop.hive.ql.exec.mr.ExecReducer.close(ExecReducer.java:287)
        at org.apache.hadoop.mapred.ReduceTask.runOldReducer(ReduceTask.java:454)
        at org.apache.hadoop.mapred.ReduceTask.run(ReduceTask.java:393)
        at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:164)
        at java.security.AccessController.doPrivileged(Native Method)
        at javax.security.auth.Subject.doAs(Subject.java:422)
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1698)
        at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:158)
Caused by: org.apache.hadoop.hive.ql.metadata.HiveException: Exception caused in the iterative training
        at hivemall.topicmodel.LDAUDTF.runIterativeTraining(LDAUDTF.java:511)
        at hivemall.topicmodel.LDAUDTF.close(LDAUDTF.java:309)
        at org.apache.hadoop.hive.ql.exec.UDTFOperator.closeOp(UDTFOperator.java:152)
        at org.apache.hadoop.hive.ql.exec.Operator.close(Operator.java:683)
        at org.apache.hadoop.hive.ql.exec.Operator.close(Operator.java:697)
        at org.apache.hadoop.hive.ql.exec.Operator.close(Operator.java:697)
        at org.apache.hadoop.hive.ql.exec.mr.ExecReducer.close(ExecReducer.java:279)
        ... 7 more
Caused by: java.lang.OutOfMemoryError: Java heap space
        at hivemall.topicmodel.LDAUDTF.runIterativeTraining(LDAUDTF.java:352)
        ... 13 more



Error: java.lang.RuntimeException: Hive Runtime Error while closing operators: Exception caused in the iterative training
        at org.apache.hadoop.hive.ql.exec.mr.ExecReducer.close(ExecReducer.java:287)
        at org.apache.hadoop.mapred.ReduceTask.runOldReducer(ReduceTask.java:454)
        at org.apache.hadoop.mapred.ReduceTask.run(ReduceTask.java:393)
        at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:164)
        at java.security.AccessController.doPrivileged(Native Method)
        at javax.security.auth.Subject.doAs(Subject.java:422)
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1698)
        at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:158)
Caused by: org.apache.hadoop.hive.ql.metadata.HiveException: Exception caused in the iterative training
        at hivemall.topicmodel.LDAUDTF.runIterativeTraining(LDAUDTF.java:511)
        at hivemall.topicmodel.LDAUDTF.close(LDAUDTF.java:309)
        at org.apache.hadoop.hive.ql.exec.UDTFOperator.closeOp(UDTFOperator.java:152)
        at org.apache.hadoop.hive.ql.exec.Operator.close(Operator.java:683)
        at org.apache.hadoop.hive.ql.exec.Operator.close(Operator.java:697)
        at org.apache.hadoop.hive.ql.exec.Operator.close(Operator.java:697)
        at org.apache.hadoop.hive.ql.exec.mr.ExecReducer.close(ExecReducer.java:279)
        ... 7 more
Caused by: java.nio.BufferUnderflowException
        at java.nio.DirectByteBuffer.get(DirectByteBuffer.java:271)
        at java.nio.ByteBuffer.get(ByteBuffer.java:715)
        at hivemall.topicmodel.LDAUDTF.runIterativeTraining(LDAUDTF.java:356)
        ... 13 more

Error: java.lang.RuntimeException: Hive Runtime Error while closing operators: Exception caused in the iterative training
        at org.apache.hadoop.hive.ql.exec.mr.ExecReducer.close(ExecReducer.java:287)
        at org.apache.hadoop.mapred.ReduceTask.runOldReducer(ReduceTask.java:454)
        at org.apache.hadoop.mapred.ReduceTask.run(ReduceTask.java:393)
        at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:164)
        at java.security.AccessController.doPrivileged(Native Method)
        at javax.security.auth.Subject.doAs(Subject.java:422)
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1698)
        at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:158)
Caused by: org.apache.hadoop.hive.ql.metadata.HiveException: Exception caused in the iterative training
        at hivemall.topicmodel.LDAUDTF.runIterativeTraining(LDAUDTF.java:511)
        at hivemall.topicmodel.LDAUDTF.close(LDAUDTF.java:309)
        at org.apache.hadoop.hive.ql.exec.UDTFOperator.closeOp(UDTFOperator.java:152)
        at org.apache.hadoop.hive.ql.exec.Operator.close(Operator.java:683)
        at org.apache.hadoop.hive.ql.exec.Operator.close(Operator.java:697)
        at org.apache.hadoop.hive.ql.exec.Operator.close(Operator.java:697)
        at org.apache.hadoop.hive.ql.exec.mr.ExecReducer.close(ExecReducer.java:279)
        ... 7 more
Caused by: java.lang.NegativeArraySizeException
        at hivemall.topicmodel.LDAUDTF.runIterativeTraining(LDAUDTF.java:352)
        ... 13 more


## How to use this feature?

When fixed people will be able to run LDA.
